### PR TITLE
Minor installation script fixes

### DIFF
--- a/utils/client_setup.sh
+++ b/utils/client_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 sudo add-apt-repository ppa:openjdk-r/ppa -y
 
-sudo apt-get update && apt-get install -y \
+sudo apt-get update && sudo apt-get install -y \
 	build-essential \
 	curl \
 	screen \
@@ -12,10 +12,10 @@ sudo apt-get update && apt-get install -y \
 	htop tree zsh fish
 
 sudo apt-get update -y
-sudo apt-get upgrade -y
+sudo env DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
 
 wget https://bootstrap.pypa.io/get-pip.py
-sudo python get-pip.py 
+sudo python get-pip.py
 sudo apt-get install unzip -y
 sudo apt-get install libpcap-dev -y
 sudo pip install boto3

--- a/utils/fedora_setup.sh
+++ b/utils/fedora_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 sudo add-apt-repository ppa:openjdk-r/ppa -y
 
-sudo apt-get update && apt-get install -y \
+sudo apt-get update && sudo apt-get install -y \
 	build-essential \
 	curl \
 	screen \
@@ -12,7 +12,7 @@ sudo apt-get update && apt-get install -y \
 	htop tree zsh fish
 
 sudo apt-get update -y
-sudo apt-get upgrade -y
+sudo env DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
 
 sudo apt-get install openjdk-8-jdk -y
 sudo apt-get install maven -y


### PR DESCRIPTION
The initial "apt-get install" invocation was missing "sudo" and hence
those packages would fail to install if the script were run as an
unprivileged user (as is implied by the use of "sudo" elsewhere).

Also, some options were added to the "apt-get upgrade" statement to
ensure that the upgrade is done in unattended mode and the system will
not prompt for answers if necessary.
