### PR TITLE
Make GitHub VTUL/VT-Fedora-Benchmark the canonical repository

### DIFF
--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
 RUN wget -q https://bootstrap.pypa.io/get-pip.py -O get-pip.py && python get-pip.py && pip install boto3 pika xmltodict requests && rm get-pip.py
 
 ENV BENCHMARK_HOME /vt-fedora-benchmark/experiments
-ENV BENCHMARK_URL https://DedoCibula@bitbucket.org/DedoCibula/vt-fedora-benchmark.git
+ENV BENCHMARK_URL https://github.com/VTUL/VT-Fedora-Benchmark.git
 ENV FITS_URL http://projects.iq.harvard.edu/files/fits/files/fits-0.9.0.zip?m=1449588471
 
 RUN git clone "$BENCHMARK_URL" vt-fedora-benchmark

--- a/user_scripts/docker/centos_client_bootstrap.sh
+++ b/user_scripts/docker/centos_client_bootstrap.sh
@@ -9,7 +9,7 @@ sudo yum -y install \
     ntp \
     vim \
     wget
-git clone https://DedoCibula@bitbucket.org/DedoCibula/vt-fedora-benchmark.git
+git clone https://github.com/VTUL/VT-Fedora-Benchmark.git vt-fedora-benchmark
 ln -s vt-fedora-benchmark/orchestrators/docker_orchestrator.py collector.py
 
 curl -fsSL https://get.docker.com/ | sh

--- a/user_scripts/docker/ubuntu_client_bootstrap.sh
+++ b/user_scripts/docker/ubuntu_client_bootstrap.sh
@@ -9,7 +9,7 @@ sudo apt-get upgrade && sudo apt-get update && sudo apt-get install -y \
     ntp \
     vim \
     wget
-git clone https://DedoCibula@bitbucket.org/DedoCibula/vt-fedora-benchmark.git
+git clone https://github.com/VTUL/VT-Fedora-Benchmark.git vt-fedora-benchmark
 ln -s vt-fedora-benchmark/orchestrators/docker_orchestrator.py collector.py
 
 curl -fsSL https://get.docker.com/ | sh

--- a/user_scripts/docker/ubuntu_client_with_rabbitmq_bootstrap.sh
+++ b/user_scripts/docker/ubuntu_client_with_rabbitmq_bootstrap.sh
@@ -9,7 +9,7 @@ sudo apt-get upgrade && sudo apt-get update && sudo apt-get install -y \
     ntp \
     vim \
     wget
-git clone https://DedoCibula@bitbucket.org/DedoCibula/vt-fedora-benchmark.git
+git clone https://github.com/VTUL/VT-Fedora-Benchmark.git vt-fedora-benchmark
 ln -s vt-fedora-benchmark/orchestrators/docker_orchestrator.py collector.py
 
 curl -fsSL https://get.docker.com/ | sh

--- a/user_scripts/rkt/ubuntu_client_bootstrap.sh
+++ b/user_scripts/rkt/ubuntu_client_bootstrap.sh
@@ -9,7 +9,7 @@ sudo apt-get upgrade && sudo apt-get update && sudo apt-get install -y \
     ntp \
     vim \
     wget
-git clone https://DedoCibula@bitbucket.org/DedoCibula/vt-fedora-benchmark.git
+git clone https://github.com/VTUL/VT-Fedora-Benchmark.git vt-fedora-benchmark
 ln -s vt-fedora-benchmark/orchestrators/rkt_orchestrator.py collector.py
 
 wget https://github.com/coreos/rkt/releases/download/v1.3.0/rkt-v1.3.0.tar.gz

--- a/user_scripts/rkt/ubuntu_client_with_rabbitmq_bootstrap.sh
+++ b/user_scripts/rkt/ubuntu_client_with_rabbitmq_bootstrap.sh
@@ -9,7 +9,7 @@ sudo apt-get upgrade && sudo apt-get update && sudo apt-get install -y \
     ntp \
     vim \
     wget
-git clone https://DedoCibula@bitbucket.org/DedoCibula/vt-fedora-benchmark.git
+git clone https://github.com/VTUL/VT-Fedora-Benchmark.git vt-fedora-benchmark
 ln -s vt-fedora-benchmark/orchestrators/rkt_orchestrator.py collector.py
 
 wget https://github.com/coreos/rkt/releases/download/v1.3.0/rkt-v1.3.0.tar.gz

--- a/user_scripts/ubuntu_fedora_bootstrap.sh
+++ b/user_scripts/ubuntu_fedora_bootstrap.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 sudo apt-get upgrade && sudo apt-get update && sudo apt-get install -y git
-git clone https://DedoCibula@bitbucket.org/DedoCibula/vt-fedora-benchmark.git
+git clone https://github.com/VTUL/VT-Fedora-Benchmark.git vt-fedora-benchmark
 vt-fedora-benchmark/utils/fedora_setup.sh

--- a/user_scripts/vm/ubuntu_client_bootstrap.sh
+++ b/user_scripts/vm/ubuntu_client_bootstrap.sh
@@ -4,7 +4,7 @@ RABBITMQ_USERNAME="admin"
 RABBITMQ_PASSWORD="admin"
 
 sudo apt-get upgrade && sudo apt-get update && sudo apt-get install -y git
-git clone https://DedoCibula@bitbucket.org/DedoCibula/vt-fedora-benchmark.git
+git clone https://github.com/VTUL/VT-Fedora-Benchmark.git vt-fedora-benchmark
 vt-fedora-benchmark/utils/client_setup.sh
 ln -s vt-fedora-benchmark/orchestrators/process_orchestrator.py collector.py
 

--- a/user_scripts/vm/ubuntu_client_with_rabbitmq_bootstrap.sh
+++ b/user_scripts/vm/ubuntu_client_with_rabbitmq_bootstrap.sh
@@ -17,7 +17,7 @@ sudo service rabbitmq-server restart
 rm rabbitmq-signing-key-public.asc
 
 sudo apt-get upgrade && sudo apt-get update && sudo apt-get install -y git
-git clone https://DedoCibula@bitbucket.org/DedoCibula/vt-fedora-benchmark.git
+git clone https://github.com/VTUL/VT-Fedora-Benchmark.git vt-fedora-benchmark
 vt-fedora-benchmark/utils/client_setup.sh
 ln -s vt-fedora-benchmark/orchestrators/process_orchestrator.py collector.py
 


### PR DESCRIPTION
Alter "git clone" checkouts of repository so they fetch from the VTUL
repository, not Andrej's personal repository hosted on BitBucket.
