### PR TITLE
Bootstrap script fixes and extensions

### DIFF
--- a/user_scripts/vm/ubuntu_client_bootstrap.sh
+++ b/user_scripts/vm/ubuntu_client_bootstrap.sh
@@ -2,8 +2,14 @@
 RABBITMQ_URL=
 RABBITMQ_USERNAME="admin"
 RABBITMQ_PASSWORD="admin"
-
-sudo apt-get upgrade && sudo apt-get update && sudo apt-get install -y git
+if [ $# -ge 1 ]; then
+  RABBITMQ_URL="$1"
+fi
+if [ $# -ge 2 ]; then
+  shift;
+  echo -n "Ignoring extra arguments: $@"
+fi
+sudo apt-get update && sudo apt-get install -y git
 git clone https://github.com/VTUL/VT-Fedora-Benchmark.git vt-fedora-benchmark
 vt-fedora-benchmark/utils/client_setup.sh
 ln -s vt-fedora-benchmark/orchestrators/process_orchestrator.py collector.py

--- a/user_scripts/vm/ubuntu_client_with_rabbitmq_bootstrap.sh
+++ b/user_scripts/vm/ubuntu_client_with_rabbitmq_bootstrap.sh
@@ -16,7 +16,7 @@ sudo rabbitmqctl delete_user guest
 sudo service rabbitmq-server restart
 rm rabbitmq-signing-key-public.asc
 
-sudo apt-get upgrade && sudo apt-get update && sudo apt-get install -y git
+sudo apt-get update && sudo apt-get install -y git
 git clone https://github.com/VTUL/VT-Fedora-Benchmark.git vt-fedora-benchmark
 vt-fedora-benchmark/utils/client_setup.sh
 ln -s vt-fedora-benchmark/orchestrators/process_orchestrator.py collector.py

--- a/utils/fedora_setup.sh
+++ b/utils/fedora_setup.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+FEDORA_DATA="/opt/fedora/fedora-data"
+if [ $# -ge 1 ]; then
+  FEDORA_DATA="$1"
+fi
+if [ $# -ge 2 ]; then
+  shift;
+  echo -n "Ignoring extra arguments: $@"
+fi
+
 sudo add-apt-repository ppa:openjdk-r/ppa -y
 
 sudo apt-get update && sudo apt-get install -y \
@@ -23,11 +32,10 @@ sudo ln -s $(readlink -f /usr/bin/java | sed "s:bin/java::" | sed "s:/jre/::") /
 
 sudo apt-get install tomcat7 tomcat7-admin -y
 
-cd
-mkdir fedora-data
-sudo chown tomcat7:tomcat7 fedora-data
-sudo sed -i '0,/JAVA_OPTS=".*"/s//JAVA_OPTS=\"-Djava.awt.headless=true -Xmx512m -XX:MaxPermSize=512m -XX:+UseConcMarkSweepGC -Dfcrepo.home=${HOME}\/fedora-data\"/' /etc/default/tomcat7
-sudo sed -i "s:\${HOME}:${HOME}:" /etc/default/tomcat7
+mkdir -p "$FEDORA_DATA"
+sudo chown tomcat7:tomcat7 "$FEDORA_DATA"
+sudo sed -i '0,/JAVA_OPTS=".*"/s//JAVA_OPTS=\"-Djava.awt.headless=true -Xmx512m -XX:MaxPermSize=512m -XX:+UseConcMarkSweepGC -Dfcrepo.home=${FEDORA_DATA}\"/' /etc/default/tomcat7
+sudo sed -i "s:\${FEDORA_DATA}:${FEDORA_DATA}:" /etc/default/tomcat7
 
 cd
 curl -s https://api.github.com/repos/fcrepo4/fcrepo4/releases \


### PR DESCRIPTION
The "sudo apt-get upgrade && sudo apt-get update" commands are in the
wrong order.  The package lists should be updated (via "apt-get
update") before the packages are upgraded (via "apt-get upgrade").  As
things stand, the "sudo apt-get upgrade" will upgrade zero packages
because they will all be up to date already (because the package lists
reference when the VM image was created).

This fix simply updates the package lists and doesn't upgrade the rest
of the packages.  This is so that the installation of Git will succeed. Instead, we postpone updating of all the packages to when it is done
as part of "utils/client_setup.sh".

We also change ubuntu_client_bootstrap.sh so that the RABBITMQ_URL can
optionally be passed in as a parameter when invoking the script.  This
paves the way for provisioning via, e.g., the Vagrant shell provisioner
and passing in the RABBITMQ_URL value when setting up the machine that
way.
